### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-major-version-tag.yml
+++ b/.github/workflows/update-major-version-tag.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-majorver:
     name: Update Major Version Tag
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: nowactions/update-majorver@v1


### PR DESCRIPTION
Potential fix for [https://github.com/joshjohanning/approveops/security/code-scanning/1](https://github.com/joshjohanning/approveops/security/code-scanning/1)

To fix this issue, explicitly declare the required `permissions` for the job or the workflow. In this case, since the job updates repository tags, the minimal necessary permission is `contents: write`. Insert a `permissions:` block (with proper YAML indentation) either at the root level (for all jobs) or under the `update-majorver` job (just for that job). For clarity and precision, add under the affected job.

- Edit `.github/workflows/update-major-version-tag.yml`
- Insert `permissions:\n  contents: write` immediately after the job name (line 10).
- No new dependencies, imports, or additional changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
