### PR TITLE
chore: update publish-github-action to latest version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 20
       - name: install ncc
         run: npm i -g @vercel/ncc
-      - uses: joshjohanning/publish-github-action@v1.4.0
+      - uses: joshjohanning/publish-github-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           npm_package_command: npm run package


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow. It changes the version of the `joshjohanning/publish-github-action` action from a specific version (`v1.4.0`) to the general `v1` tag, which will automatically use the latest v1 release.