### PR TITLE
test: add regression test for non-team-member /approve before valid approval

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -353,6 +353,30 @@ describe('ApproveOps Action', () => {
       expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining('comment id 1'));
     });
 
+    test('should approve when first /approve is from non-team member but later one is from team member', async () => {
+      mockOctokit.paginate.mockResolvedValueOnce([{ login: 'team-member' }]);
+
+      mockOctokit.paginate.mockResolvedValueOnce([
+        {
+          id: 1,
+          body: '/approve',
+          user: { login: 'non-team-member' }
+        },
+        {
+          id: 2,
+          body: '/approve',
+          user: { login: 'team-member' }
+        }
+      ]);
+
+      mockOctokit.rest.issues.createComment.mockResolvedValue({});
+
+      await run();
+
+      expect(mockCore.setOutput).toHaveBeenCalledWith('approved', 'true');
+      expect(mockCore.info).toHaveBeenCalledWith(expect.stringContaining('comment id 2'));
+    });
+
     test('should handle case-sensitive approval command', async () => {
       mockOctokit.paginate.mockResolvedValueOnce([{ login: 'team-member' }]);
 


### PR DESCRIPTION
## Summary

Adds a regression test confirming that when a non-team-member comments `/approve` before a valid team member does, the action correctly skips the unauthorized comment and finds the later authorized one.

This behavior is already correct in the current Node.js implementation (the `break` only fires inside the `teamMembers.has(actor)` check), but the earlier shell-script version (v2) had a real bug where the `break` executed on any `/approve` match regardless of authorization.

A separate hotfix for v2 is being submitted in parallel. #100 

References #98