### PR TITLE
Fix v2: only break on authorized /approve, not first match

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,8 +67,13 @@ runs:
             id=$(echo $comment | base64 --decode | jq -r '.id')
             if [[ "$body" == "$approveCommand" ]]; then
                 echo "Approval command found in comment id $id ..."
-                echo $users | grep -q "$actor" && echo "Found $actor in team: ${{ inputs.team-name }}" && authorized=true || echo "Not found $actor in team: ${{ inputs.team-name }}"
-                break
+                if echo $users | grep -q "$actor"; then
+                    echo "Found $actor in team: ${{ inputs.team-name }}"
+                    authorized=true
+                    break
+                else
+                    echo "Not found $actor in team: ${{ inputs.team-name }}"
+                fi
             else
                 echo "Approval command not found in comment id $id ..."
             fi


### PR DESCRIPTION
## V2 Hotfix

### Bug

The shell script `break`s out of the comment loop on the **first** `/approve` match, regardless of whether the commenter is in the required team. If a non-team-member comments `/approve` before a valid team member, the action fails even though a valid approval exists.

### Fix

Moved the `break` inside the authorization check so it only exits the loop when a team member's `/approve` is found. Non-team-member `/approve` comments are now skipped and the loop continues.

### Release steps

1. Merge this PR into `release/v2`
2. Create tag `v2.0.6` from `release/v2`
3. Update the `v2` tag to point to `v2.0.6`
4. Create a GitHub release for `v2.0.6`

Fixes #98